### PR TITLE
Remove a cross-platform compat bug in python builder

### DIFF
--- a/anaconda_lib/builder/python_builder.py
+++ b/anaconda_lib/builder/python_builder.py
@@ -68,7 +68,7 @@ class AnacondaSetPythonBuilder(object):
 
         template_file = os.path.join(
             os.path.dirname(__file__),
-            '../../', 'templates', 'python_build.tpl'
+            '..', '..', 'templates', 'python_build.tpl'
         )
         with open(template_file, 'r', encoding='utf8') as tplfile:
             template = Template(tplfile.read())

--- a/anaconda_lib/workers/interpreter.py
+++ b/anaconda_lib/workers/interpreter.py
@@ -151,7 +151,13 @@ class Interpreter(object):
                     os.path.expandvars(get_interpreter(view))
                 )
             )
-            python = urldata.path
+            
+            if len(urldata.scheme) == 1:
+                # Assume this comes from a Windows path if schema is a single character
+                python = os.path.join('{}:'.format(urldata.scheme), urldata.path)
+            else:
+                python = urldata.path
+                
             if '$VIRTUAL_ENV' in python:
                 Log.warning(
                     'WARNING: your anaconda configured python interpreter '

--- a/anaconda_lib/workers/interpreter.py
+++ b/anaconda_lib/workers/interpreter.py
@@ -153,7 +153,7 @@ class Interpreter(object):
             )
             
             if len(urldata.scheme) == 1:
-                # Assume this comes from a Windows path if schema is a single character
+                # Assume this comes from a Windows path if scheme is a single character
                 python = os.path.join('{}:'.format(urldata.scheme), urldata.path)
             else:
                 python = urldata.path


### PR DESCRIPTION
python_build.tpl was being referenced in a relative path with raw `../../` rather than using the os.path.join invocation it was _already_ within. I'm guessing someone just didn't have their second coffee that day.